### PR TITLE
Add compat entry for Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,6 @@ name = "ShapeFactory"
 uuid = "5f2830c0-a9f2-11e9-177d-47448fa133db"
 authors = ["__zaika_dns"]
 version = "0.1.0"
+
+[compat]
+julia = "1"


### PR DESCRIPTION
This pull request adds a `[compat]` entry for Julia. This is required in order for your package to be registered in the General registry.

cc: @synxroform 